### PR TITLE
feature: rename console server to webserver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "src/ai/backend/console/static"]
+[submodule "src/ai/backend/web/static"]
 	path = src/ai/backend/web/static
 	url = https://github.com/lablup/backend.ai-app.git

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A minimal webapp to convert web session requests to API requests.
 
 Prepare a Python virtualenv (Python 3.7 or higher) and a Redis server (5.0 or higher).
 
-```webserver
+```console
 $ git clone https://github.com/lablup/backend.ai-webserver webserver
 $ cd webserver
 $ pip install -U -e .
@@ -37,7 +37,7 @@ into the `src/ai/backend/web/static` directory.
 
 To download and deploy web UI from pre-built source, do the following:
 
-```web UI
+```console
 git submodule init
 git submodule update
 cd src/ai/backend/web/static
@@ -54,6 +54,9 @@ Edit `webserver.conf` to match with your environment.
 
 ## Usage
 
+To execute web server, run command below. (for debugging, append a `--debug` flag)
+
+
 ```console
-$ python -m ai.backend.console.server
+$ python -m ai.backend.web.server
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A minimal webapp to convert web session requests to API requests.
 
 Prepare a Python virtualenv (Python 3.7 or higher) and a Redis server (5.0 or higher).
 
-```console
+```webserver
 $ git clone https://github.com/lablup/backend.ai-webserver webserver
 $ cd webserver
 $ pip install -U -e .
@@ -16,40 +16,40 @@ $ cp webserver.sample.conf webserver.conf
 
 ## Mode
 
-If `service.mode` is set "webconsole" (the default), the console server handles
+If `service.mode` is set "webui" (the default), the webserver handles
 PWA-style fallbacks (e.g., serving `index.html` when there are no matching
 files for the requested URL path).
 The PWA must exclude `/server` and `/func` URL prefixes from its own routing
-to work with the console server's web sessions and the API proxy.
+to work with the webserver's web sessions and the API proxy.
 
-If it is set "static", the console server serves the static files as-is,
+If it is set "static", the webserver serves the static files as-is,
 without any fallbacks or hooking, while preserving the `/server` and `/func`
 prefixed URLs and their functionalities.
 
-If you want to serve console in console-server with "webconsole" mode, prepare static console source by choosing one of the followings.
+If you want to serve web UI in webserver with "webui" mode, prepare static web UI source by choosing one of the followings.
 
-### Option 1: Build console from source
+### Option 1: Build web UI from source
 
-Build **[backend.ai-console](https://github.com/lablup/backend.ai-console)** and copy all files under `build/bundle`
-into the `src/ai/backend/console/static` directory.
+Build **[backend.ai-webui](https://github.com/lablup/backend.ai-webui)** and copy all files under `build/bundle`
+into the `src/ai/backend/web/static` directory.
 
-### Option 2: Use pre-built console
+### Option 2: Use pre-built web UI
 
-To download and deploy console from pre-built source, do the following:
+To download and deploy web UI from pre-built source, do the following:
 
-```console
+```web UI
 git submodule init
 git submodule update
-cd src/ai/backend/console/static
+cd src/ai/backend/web/static
 git checkout main  # or target branch
 git fetch
 git pull
 ```
 ### Setup configuration for webserver
 
-You don't have to write `config.toml` for the console as this console server auto-generates it on-the-fly.
+You don't have to write `config.toml` for the web UI as this webserver auto-generates it on-the-fly.
 
-Edit `console-server.conf` to match with your environment.
+Edit `webserver.conf` to match with your environment.
 
 
 ## Usage

--- a/changes/32.misc
+++ b/changes/32.misc
@@ -1,0 +1,1 @@
+Update the name of console-server to webserver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [tool.towncrier]
-package = "ai.backend.console"
+package = "ai.backend.web"
 filename = "CHANGELOG.md"
 directory = "changes/"
 title_format = "{version} ({project_date})"
 template = "changes/template.md"
-issue_format = "([#{issue}](https://github.com/lablup/backend.ai-console-server/issues/{issue}))"
+issue_format = "([#{issue}](https://github.com/lablup/backend.ai-webserver/issues/{issue}))"
 underlines = ["-", "", ""]
 
 [[tool.towncrier.type]]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = backend.ai-webserver
 version = attr: src.ai.backend.web.__version__
-description = Backend.AI Console Server
+description = Backend.AI Web Server
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://backend.ai

--- a/src/ai/backend/web/__init__.py
+++ b/src/ai/backend/web/__init__.py
@@ -1,3 +1,3 @@
 __version__ = '20.09.5'
 
-user_agent = f'Backend.AI Console Server {__version__}'
+user_agent = f'Backend.AI Web Server {__version__}'

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -34,9 +34,8 @@ from . import __version__, user_agent
 from .logging import BraceStyleAdapter
 from .proxy import web_handler, websocket_handler, web_plugin_handler
 
-log = BraceStyleAdapter(logging.getLogger('ai.backend.console.server'))
-
-static_path = Path(pkg_resources.resource_filename('ai.backend.console', 'static')).resolve()
+log = BraceStyleAdapter(logging.getLogger('ai.backend.web.server'))
+static_path = Path(pkg_resources.resource_filename('ai.backend.web', 'static')).resolve()
 assert static_path.is_dir()
 
 
@@ -212,7 +211,7 @@ cache_patterns = {
     r'\.(?:manifest|appcache|html?|xml|json|ini|toml)$': {
         'Cache-Control': 'no-store'
     },
-    r'(?:backend.ai-console.js)$': {
+    r'(?:backend.ai-webui.js)$': {
         'Cache-Control': 'no-store'
     },
     r'\.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc|woff|woff2)$': {
@@ -443,7 +442,7 @@ async def server_main(loop, pidx, args):
     cors.add(app.router.add_route('POST', '/func/{path:.*$}', web_handler))
     cors.add(app.router.add_route('PATCH', '/func/{path:.*$}', web_handler))
     cors.add(app.router.add_route('DELETE', '/func/{path:.*$}', web_handler))
-    if config['service']['mode'] == 'webconsole':
+    if config['service']['mode'] == 'webui':
         fallback_handler = console_handler
     elif config['service']['mode'] == 'static':
         fallback_handler = static_handler
@@ -531,11 +530,11 @@ def main(config, debug):
             },
         },
     })
-    log.info('Backend.AI Console Server {0}', __version__)
+    log.info('Backend.AI Web Server {0}', __version__)
     log.info('runtime: {0}', sys.prefix)
-    log_config = logging.getLogger('ai.backend.console.config')
+    log_config = logging.getLogger('ai.backend.web.config')
     log_config.debug('debug mode enabled.')
-    print('== Console Server configuration ==')
+    print('== Web Server configuration ==')
     pprint(config)
     log.info('serving at {0}:{1}', config['service']['ip'], config['service']['port'])
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -22,7 +22,7 @@ async def test_get_api_session(mocker):
     mock_get_session = AsyncMock(return_value={
         'authenticated': False
     })
-    mocker.patch('ai.backend.console.auth.get_session', mock_get_session)
+    mocker.patch('ai.backend.web.auth.get_session', mock_get_session)
     with pytest.raises(web.HTTPUnauthorized):
         await get_api_session(mock_request)
     mock_get_session.assert_awaited_once()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, AsyncMock
 
 from aiohttp import web
 
-from ai.backend.console.auth import get_api_session, get_anonymous_session
+from ai.backend.web.auth import get_api_session, get_anonymous_session
 
 
 class DummyRequest:
@@ -31,7 +31,7 @@ async def test_get_api_session(mocker):
         'authenticated': True,
         'token': {'type': 'something-else', },
     })
-    mocker.patch('ai.backend.console.auth.get_session', mock_get_session)
+    mocker.patch('ai.backend.web.auth.get_session', mock_get_session)
     with pytest.raises(web.HTTPBadRequest):
         await get_api_session(mock_request)
     mock_get_session.assert_awaited_once()
@@ -40,7 +40,7 @@ async def test_get_api_session(mocker):
         'authenticated': True,
         'token': {'type': 'keypair', 'access_key': 'ABC', 'secret_key': 'xyz'},
     })
-    mocker.patch('ai.backend.console.auth.get_session', mock_get_session)
+    mocker.patch('ai.backend.web.auth.get_session', mock_get_session)
     api_session = await get_api_session(mock_request)
     mock_get_session.assert_awaited_once()
     async with api_session:
@@ -61,7 +61,7 @@ async def test_get_api_session_with_specific_api_endpoint(mocker):
         'token': {'type': 'keypair', 'access_key': 'ABC', 'secret_key': 'xyz'},
     })
     specific_api_endpoint = 'https://alternative.backend.ai'
-    mocker.patch('ai.backend.console.auth.get_session', mock_get_session)
+    mocker.patch('ai.backend.web.auth.get_session', mock_get_session)
     api_session = await get_api_session(mock_request, specific_api_endpoint)
     mock_get_session.assert_awaited_once()
     async with api_session:
@@ -74,7 +74,7 @@ async def test_get_anonymous_session(mocker):
         'api': {'domain': 'default', 'endpoint': 'https://api.backend.ai'},
     }})
     mock_get_session = MagicMock()
-    mocker.patch('ai.backend.console.auth.get_session', mock_get_session)
+    mocker.patch('ai.backend.web.auth.get_session', mock_get_session)
     api_session = await get_anonymous_session(mock_request)
     mock_get_session.assert_not_called()
     async with api_session:
@@ -92,7 +92,7 @@ async def test_get_anonymous_session_with_specific_api_endpoint(mocker):
     }})
     specific_api_endpoint = 'https://alternative.backend.ai'
     mock_get_session = MagicMock()
-    mocker.patch('ai.backend.console.auth.get_session', mock_get_session)
+    mocker.patch('ai.backend.web.auth.get_session', mock_get_session)
     api_session = await get_anonymous_session(mock_request, specific_api_endpoint)
     mock_get_session.assert_not_called()
     async with api_session:

--- a/webserver.sample.conf
+++ b/webserver.sample.conf
@@ -11,12 +11,12 @@ wsproxy.url = ""
 # Set or enable it when using nginx proxy
 #force-endpoint-protocol = "https"
 
-# "webconsole" mode is for serving "backend.ai-console" PWA,
+# "webui" mode is for serving "backend.ai-webui" PWA,
 # where non-existent URLs are fall-back to "index.html"
 # and "config.ini" is generated on the fly.
 # "static" mode is for serving the static directory as-is,
 # without any fallback or hooks.
-mode = "webconsole"
+mode = "webui"
 # Enable signup feature support.
 enable_signup = false
 # Let anonymous user can request an email with a link to change password.
@@ -43,7 +43,7 @@ max_file_upload_size = 4294967296
 
 [plugin]
 # Comma-separated string
-# Should be same as plugin file in console plugin directory.
+# Should be same as plugin file in web UI plugin directory.
 #page = ""
 
 [ui]
@@ -75,7 +75,7 @@ login_block_time = 1200  # 20 min (in sec)
 # to login consecutively over this number, login with the account
 # is blocked for ``block_time``.
 login_allowed_fail_count = 10
-# Auto logout when user closes all Backend.AI console tab / window
+# Auto logout when user closes all Backend.AI web UI tab / window
 #auto_logout = false
 
 # Add a manually configured license information shown in the UI.


### PR DESCRIPTION
This PR updates the name ```console-server``` to ```webserver``` for better understanding.