### PR TITLE
fix: send cookies along with an api request

### DIFF
--- a/changes/35.fix
+++ b/changes/35.fix
@@ -1,0 +1,1 @@
+Send cookies for an api request. This is required to cookie-based authentication for each request.

--- a/src/ai/backend/web/proxy.py
+++ b/src/ai/backend/web/proxy.py
@@ -127,6 +127,8 @@ async def web_handler(request, *, is_anonymous=False) -> web.StreamResponse:
             # but need to keep the client's version header so that
             # the final clients may perform its own API versioning support.
             request_api_version = request.headers.get('X-BackendAI-Version', None)
+            # Deliver cookie for token-based authentication.
+            api_session.aiohttp_session.cookie_jar.update_cookies(request.cookies)
             # We treat all requests and responses as streaming universally
             # to be a transparent proxy.
             api_rqst = Request(

--- a/src/ai/backend/web/proxy.py
+++ b/src/ai/backend/web/proxy.py
@@ -199,6 +199,8 @@ async def web_plugin_handler(request, *, is_anonymous=False) -> web.StreamRespon
                 body['domain'] = request.app['config']['api']['domain']
                 content = json.dumps(body).encode('utf8')
             request_api_version = request.headers.get('X-BackendAI-Version', None)
+            # Deliver cookie for token-based authentication.
+            api_session.aiohttp_session.cookie_jar.update_cookies(request.cookies)
             api_rqst = Request(
                 request.method, path, content,
                 params=request.query,


### PR DESCRIPTION
This is required for cookie-based per-request authentication.