### PR TITLE
fix: max_memory_per_container value in configuration file

### DIFF
--- a/changes/39.fix
+++ b/changes/39.fix
@@ -1,0 +1,1 @@
+Add max_memory_per_container in configuration file to limit memory allocation for each container.

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -75,6 +75,7 @@ autoLogout = {{auto_logout}}
 [resources]
 openPortToPublic = {{open_port_to_public}}
 maxCPUCoresPerContainer = {{max_cpu_cores_per_container}}
+maxMemoryPerContainer = {{max_memory_per_container}}
 maxCUDADevicesPerContainer = {{max_cuda_devices_per_container}}
 maxCUDASharesPerContainer = {{max_cuda_shares_per_container}}
 maxShmPerContainer = {{max_shm_per_container}}
@@ -148,6 +149,7 @@ async def console_handler(request: web.Request) -> web.StreamResponse:
         if 'resources' in config:
             open_port_to_public = 'true' if config['resources'].get('open_port_to_public') else 'false'
             max_cpu_cores_per_container = config['resources'].get('max_cpu_cores_per_container', 64)
+            max_memory_per_container = config['resources'].get('max_memory_per_container', 64)
             max_cuda_devices_per_container = config['resources'].get(
                     'max_cuda_devices_per_container', 16)
             max_cuda_shares_per_container = config['resources'].get(
@@ -157,6 +159,7 @@ async def console_handler(request: web.Request) -> web.StreamResponse:
         else:
             open_port_to_public = 'false'
             max_cpu_cores_per_container = 64
+            max_memory_per_container = 64
             max_cuda_devices_per_container = 16
             max_cuda_shares_per_container = 16
             max_shm_per_container = 2
@@ -185,6 +188,7 @@ async def console_handler(request: web.Request) -> web.StreamResponse:
                 'true' if config['session'].get('auto_logout') else 'false',
             'open_port_to_public': open_port_to_public,
             'max_cpu_cores_per_container': max_cpu_cores_per_container,
+            'max_memory_per_container': max_memory_per_container,
             'max_cuda_devices_per_container': max_cuda_devices_per_container,
             'max_cuda_shares_per_container': max_cuda_shares_per_container,
             'max_shm_per_container': max_shm_per_container,

--- a/webserver.sample.conf
+++ b/webserver.sample.conf
@@ -34,6 +34,8 @@ allow_manual_image_name_for_session = false
 open_port_to_public = false
 # Maximum CPU cores allowed per container (int)
 max_cpu_cores_per_container = 64
+# Maximum memory allowed per container (int)
+max_memory_per_container = 64
 # Maximum CUDA devices allowed per container (int)
 max_cuda_devices_per_container = 16
 # Maximum CUDA fGPUs allowed per container (int)


### PR DESCRIPTION
This PR adds max_memory_per_container value in the configuration file to limit the maximum value of memory allocation in the resource panel in the session launcher.